### PR TITLE
Add Sourceable trait and toSourceString methods

### DIFF
--- a/src/mmt-api/src/main/info/kwarc/mmt/api/Component.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/Component.scala
@@ -1,6 +1,7 @@
 package info.kwarc.mmt.api
 
 import objects._
+import utils.Sourceable
 
 /** A component of a declaration, e.g., the type of a [[Constant]] (akin to XML attributes) */
 case class DeclarationComponent(key: ComponentKey, value: ComponentContainer) extends NamedElement {
@@ -39,8 +40,9 @@ class FinalTermContainer(t: Term) extends AbstractTermContainer {
 }
 
 /** A ComponentKey identifies a [[DeclarationComponent]]. */
-abstract class ComponentKey(s : String) {
+abstract class ComponentKey(s : String) extends Sourceable {
    override def toString = s
+   def toSourceString: String = s"${this.getClass.getName}"
    def apply(cont: ComponentContainer) = DeclarationComponent(this, cont)
 }
 
@@ -80,7 +82,9 @@ case object CodComponent  extends TermComponentKey("codomain")
 case object ParamsComponent extends ObjComponentKey("params")
 
 /** custom component, e.g., in a [[info.kwarc.mmt.api.symbols.DerivedDeclaration]] */
-case class OtherComponent(s: String) extends ComponentKey(s)
+case class OtherComponent(s: String) extends ComponentKey(s) {
+  override def toSourceString: String = s"OtherComponent(${Sourceable(s)})"
+}
 
 /** components that are notations */
 abstract class NotationComponentKey(s: String) extends ComponentKey(s)

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/notations/Notation.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/notations/Notation.scala
@@ -16,9 +16,14 @@ case class InvalidNotation(msg: String) extends java.lang.Throwable
  * languages : the languages where this notation is applicable (e.g. tex, mmt, lf, mathml)
  * priority : the priority of this notation when looking for a default notation
  */
-case class NotationScope(variant : Option[String], languages : List[String], priority : Int) {
+case class NotationScope(variant : Option[String], languages : List[String], priority : Int) extends Sourceable {
   def toNode =  <scope variant={variant.getOrElse(null)} 
     languages={languages.mkString(" ")} priority={priority.toString}/>
+  def toSourceString: String = s"NotationScope(" +
+     s"${Sourceable(variant)}, " +
+     s"${Sourceable(languages)}, " +
+     s"${Sourceable(languages)}, " +
+     s"${Sourceable(priority)})"
 }
 
 object NotationScope {
@@ -39,7 +44,7 @@ object NotationScope {
  * if the only marker is SeqArg, it must hold that OMA(name, List(x)) = x because sequences of length 1 are parsed as themselves 
  */
 case class TextNotation(fixity: Fixity, precedence: Precedence, meta: Option[MPath],
-                        scope : NotationScope = NotationScope.default) extends metadata.HasMetaData {
+                        scope : NotationScope = NotationScope.default) extends metadata.HasMetaData with Sourceable {
    /** @return the list of markers used for parsing/presenting with this notations */
    lazy val markers: List[Marker] = fixity.markers
    /** @return the arity of this notation */
@@ -160,7 +165,13 @@ case class TextNotation(fixity: Fixity, precedence: Precedence, meta: Option[MPa
       (arity.numNormalArgs == args || (arity.numNormalArgs < args && arity.numSeqArgs >= 1)) &&
       (hasDelimiter || arity.numSeqArgs == 0 || args > arity.numNormalArgs + arity.numSeqArgs) && // this hacky case precludes confusion when flexary operators would disappear in the presentation
       (! att || arity.attribution)
-   }   
+   }
+
+   def toSourceString: String = s"TextNotation(" +
+      s"${Sourceable(fixity)}, " +
+      s"${Sourceable(precedence)}, " +
+      s"${Sourceable(meta)}, " +
+      s"${Sourceable(scope)})"
 }
 
 object TextNotation {

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/notations/NotationComponents.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/notations/NotationComponents.scala
@@ -4,7 +4,7 @@ import info.kwarc.mmt.api._
 import utils._
 
 /** Objects of type Marker make up the pattern of a Notation */
-sealed abstract class Marker {
+sealed abstract class Marker extends Sourceable {
    override def toString : String
 }
 
@@ -42,6 +42,7 @@ case class Delim(s: String) extends Delimiter {
       }
    }
    def text = if (s == "%w") " " else s
+   def toSourceString: String = s"Delim(${Sourceable(s)})"
 }
 
 /**
@@ -52,6 +53,8 @@ case class Delim(s: String) extends Delimiter {
 abstract class PlaceholderDelimiter extends Delimiter {
    /** empty to make them useless for parsing unless expanded */
    def text = ""
+
+   def toSourceString: String = s"${getClass.getName}()"
 }
 
 /**
@@ -83,10 +86,11 @@ object CommonMarkerProperties {
 import CommonMarkerProperties._
 
 /** bundles minor properties of markers to make the interfaces more robust */
-case class CommonMarkerProperties(precedence: Option[Precedence], localNotations: Option[Int]) {
+case class CommonMarkerProperties(precedence: Option[Precedence], localNotations: Option[Int]) extends Sourceable {
   def wlnf(n: Int) = copy(localNotations = Some(n))
   def *(remap: Int => Int) = copy(localNotations = localNotations.map(remap))
   def asStringPrefix = localNotations.map(i => "%L" + i + "_").getOrElse("")
+  def toSourceString: String = s"CommonMarkerProperties(${Sourceable(precedence)}, ${Sourceable(localNotations)})"
 }
 
 
@@ -145,6 +149,7 @@ sealed abstract class SeqArg extends ArgumentMarker {
 /** normal arguments */
 case class SimpArg(number : Int, properties: CommonMarkerProperties = noProps) extends Arg {
     def by(s:String): SimpSeqArg = SimpSeqArg(number,Delim(s), properties)
+    def toSourceString: String = s"SimpArg(${Sourceable(number)}, )"
 }
 
 /**
@@ -155,6 +160,7 @@ case class SimpArg(number : Int, properties: CommonMarkerProperties = noProps) e
 case class ImplicitArg(number: Int, properties: CommonMarkerProperties = noProps) extends ArgumentMarker {
    override def toString = properties.asStringPrefix + "%I" + number
    def *(remap: Int => Int): ImplicitArg = copy(number = remap(number), properties = properties * remap)
+   def toSourceString: String = s"ImplicitArg(${Sourceable(number)}, ${Sourceable(properties)})"
 }
 
 /**
@@ -164,6 +170,7 @@ case class ImplicitArg(number: Int, properties: CommonMarkerProperties = noProps
 
 case class SimpSeqArg(number: Int, sep: Delim, properties: CommonMarkerProperties) extends SeqArg {
   def makeCorrespondingArg(n: Int, remap: Int => Int) = SimpArg(n, properties * remap)
+  def toSourceString: String = s"SimpSeqArg(${Sourceable(number)}, ${Sourceable(sep)}, ${Sourceable(properties)})"
 }
 
 
@@ -172,7 +179,9 @@ case class SimpSeqArg(number: Int, sep: Delim, properties: CommonMarkerPropertie
  * @param defined definitions are required
  * @param dependent definitions are required
  */
-case class LabelInfo(typed: Boolean, defined: Boolean, dependent: Boolean)
+case class LabelInfo(typed: Boolean, defined: Boolean, dependent: Boolean) extends Sourceable {
+   def toSourceString: String = s"LabelInfo(${Sourceable(typed)}, ${Sourceable(defined)}, ${Sourceable(dependent)})"
+}
 
 object LabelInfo {
   def none = LabelInfo(false,false,false)
@@ -183,6 +192,7 @@ object LabelInfo {
 case class LabelArg(number : Int, info: LabelInfo, properties: CommonMarkerProperties = noProps) extends Arg {
   override def toString = properties.asStringPrefix + "L" + number.toString + (if (info.typed) "T" else "") + (if (info.defined) "D" else "")
   def by(s:String): LabelSeqArg = LabelSeqArg(number, Delim(s), info, properties)
+  def toSourceString: String = s"LabelArg(${Sourceable(number)}, ${Sourceable(info)}, ${Sourceable(properties)})"
 }
 
 /**
@@ -192,6 +202,7 @@ case class LabelArg(number : Int, info: LabelInfo, properties: CommonMarkerPrope
 case class LabelSeqArg(number: Int, sep: Delim, info: LabelInfo, properties: CommonMarkerProperties) extends SeqArg {
   override def toString = properties.asStringPrefix + "L" + number.toString + (if (info.typed) "T" else "") + (if (info.defined) "D" else "") + sep + "…"
   def makeCorrespondingArg(n: Int, remap: Int => Int) = LabelArg(n, info, properties*remap)
+  def toSourceString: String = s"LabelSeqArg(${Sourceable(number)}, ${Sourceable(sep)}, ${Sourceable(info)}, ${Sourceable(properties)})"
 }
 
 /** a variable binding
@@ -207,10 +218,12 @@ case class Var(number: Int, typed: Boolean, sep: Option[Delim], properties: Comm
    override def isSequence = sep.isDefined
    def makeCorrespondingSingleVar(n: Int, remap: Int => Int) = Var(n, typed, None, properties*remap)
    def *(remap: Int => Int): Var = copy(number = remap(number), properties = properties * remap)
+   def toSourceString: String = s"Var(${Sourceable(number)}, ${Sourceable(typed)}, ${Sourceable(sep)}, ${Sourceable(properties)})"
 }
 
 case object AttributedObject extends Marker {
    override def toString = "%a"
+   def toSourceString: String = "AttributedObject"
 }
 
 /** Verbalization markers occur in verbalization notations
@@ -222,6 +235,7 @@ sealed abstract class VerbalizationMarker extends Marker {
 case class WordMarker(word : String) extends VerbalizationMarker {
   override def toString = word
   def toParsing = Delim(word) :: Nil
+  def toSourceString: String = s"WordMarker(${Sourceable(word)})"
 }
 
 // TODO add toString method in presentation markers
@@ -237,6 +251,7 @@ sealed abstract class PresentationMarker extends Marker {
 /** groups a list of markers into a single marker */
 case class GroupMarker(elements: List[Marker]) extends PresentationMarker {
    def flatMap(f: Marker => List[Marker]) = GroupMarker(elements flatMap f)
+   def toSourceString: String = s"GroupMarker(${Sourceable(elements)})"
 }
 /** decorates a marker with various scripts */
 case class ScriptMarker(main: Marker, sup: Option[Marker], sub: Option[Marker],
@@ -247,37 +262,48 @@ case class ScriptMarker(main: Marker, sup: Option[Marker], sub: Option[Marker],
    }
    def flatMap(f: Marker => List[Marker]) =
       ScriptMarker(gMap(f)(main), sup map gMap(f), sub map gMap(f), over map gMap(f), under map gMap(f))
+   def toSourceString: String = s"ScriptMarker(" +
+      s"${Sourceable(main)}, " +
+      s"${Sourceable(sup)}, " +
+      s"${Sourceable(sub)}, "
+      s"${Sourceable(over)}, " +
+      s"${Sourceable(under)})"
 }
 /** a marker for fractions */
 case class FractionMarker(above: List[Marker], below: List[Marker], line: Boolean) extends PresentationMarker {
    def flatMap(f: Marker => List[Marker]) = {
       FractionMarker(above.flatMap(f), below.flatMap(f), line)
    }
+   def toSourceString: String = s"FractionMarker(${Sourceable(above)}, ${Sourceable(below)}, ${Sourceable(line)})"
 }
 /** a marker based on mathml mtd elements, representing table cells */
 case class TdMarker(content : List[Marker]) extends PresentationMarker {
    def flatMap(f : Marker => List[Marker]) = {
      TdMarker(content.flatMap(f))
-   } 
+   }
+   def toSourceString: String = s"TdMarker(${Sourceable(content)})"
 }
 /** a marker based on mathml mtd elements, representing table rows */
 case class TrMarker(content : List[Marker]) extends PresentationMarker {
    def flatMap(f : Marker => List[Marker]) = {
      TdMarker(content.flatMap(f))
-   } 
+   }
+   def toSourceString: String = s"TrMarker(${Sourceable(content)})"
 }
 /** a marker based on mathml mtd elements, representing tables */
 case class TableMarker(content : List[Marker]) extends PresentationMarker {
    def flatMap(f : Marker => List[Marker]) = {
      TdMarker(content.flatMap(f))
-   } 
+   }
+   def toSourceString: String = s"TableMarker(${Sourceable(content)})"
 }
 
 /**a marker representing the nth(index) root in mathml*/
 case class RootMarker(content : List[Marker], index : List[Marker] = Nil) extends PresentationMarker {
   def flatMap(f : Marker => List[Marker]) = {
     RootMarker(content.flatMap(f),index)
-  } 
+  }
+  def toSourceString: String = s"RootMarker(${Sourceable(content)}, ${Sourceable(index)})"
 }
 
 /**a maker based on mathml label*/
@@ -285,20 +311,23 @@ case class LabelMarker(content: List[Marker], label : String) extends Presentati
   def flatMap(f : Marker => List[Marker]) = {
     LabelMarker(content.flatMap(f),label)
   }
+  def toSourceString: String = s"LabelMarker(${Sourceable(content)}, ${Sourceable(label)})"
 }
 
 /** a marker for a fixed numeric value */
 case class NumberMarker(value : Delim) extends PresentationMarker {
   def flatMap(f : Marker => List[Marker]) = {
     NumberMarker(value)
-  } 
+  }
+  def toSourceString: String = s"NumberMarker(${Sourceable(value)})"
 }
 
 /**Marker for Identifier in MathML -*/
 case class IdenMarker(value: Delim) extends PresentationMarker {
   def flatMap(f : Marker => List[Marker]) = {
     IdenMarker(value)
-  } 
+  }
+  def toSourceString: String = s"IdenMarker(${Sourceable(value)})"
 }
 
 /**Marker for error elements in MathML*/
@@ -306,6 +335,7 @@ case class ErrorMarker(content: List[Marker]) extends PresentationMarker{
   def flatMap(f: Marker => List[Marker]) = {
     ErrorMarker(content)
   }
+  def toSourceString: String = s"ErrorMarker(${Sourceable(content)})"
 }
 
 /**Marker for phantom elements in MathML*/
@@ -313,6 +343,7 @@ case class PhantomMarker(content : List[Marker]) extends PresentationMarker{
   def flatMap(f: Marker => List[Marker]) = {
     PhantomMarker(content.flatMap(f))
   }
+  def toSourceString: String = s"PhantomMarker(${Sourceable(content)})"
 }
 /** a marker for mglyph, to load non-standard symbols
   *
@@ -323,17 +354,20 @@ case class GlyphMarker( src : Delim, alt: String = "Failed Loading") extends Pre
   def flatMap(f: Marker => List[Marker]) = {
     GlyphMarker(src)
   }
+  def toSourceString: String = s"GlyphMarker(${Sourceable(src)}, ${Sourceable(alt)})"
 }
 
 case class TextMarker(text : Delim) extends PresentationMarker {
   def flatMap(f:Marker => List[Marker]) = {
     TextMarker(text)
   }
+  def toSourceString: String = s"TextMarker(${Sourceable(text)})"
 }
 
 /** a marker for type of the presented object */
 case object InferenceMarker extends PresentationMarker {
    def flatMap(f: Marker => List[Marker]) = InferenceMarker
+   def toSourceString: String = "InferenceMarker"
 }
 
 object PresentationMarker {

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/notations/NotationExtension.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/notations/NotationExtension.scala
@@ -10,7 +10,7 @@ import Conversions._
  *
  * A Fixity is a high-level construct that elaborates into a list of [[Marker]]s. Parser and present only use the latter.
  */
-abstract class Fixity {
+abstract class Fixity extends Sourceable {
    /** the elaboration into markers */
    def markers: List[Marker]
    /** the string representation to use when serializing notations
@@ -24,6 +24,7 @@ abstract class Fixity {
  */
 case class Mixfix(markers: List[Marker]) extends Fixity {
    def asString = ("mixfix", markers.mkString(" "))
+   def toSourceString: String = s"Mixfix(${Sourceable(markers)})"
 }
 
 /**
@@ -60,6 +61,7 @@ abstract class SimpleFixity extends Fixity {
 case class Prefix(delim: Delimiter, impl: Int, expl: Int) extends SimpleFixity {
    lazy val markers = if (expl != 0) argsWithOp(0) else argsWithOp(0) ::: implArgs
    def asString = ("prefix", simpleArgs)
+   def toSourceString: String = s"Prefix(${Sourceable(delim)}, ${Sourceable(impl)}, ${Sourceable(expl)})"
 }
 /**
  * delimiter after the first (explicit) argument
@@ -80,12 +82,14 @@ case class Infix(delim: Delimiter, impl: Int, expl: Int, assoc: Option[Boolean])
       }
       ("infix"+assocString, simpleArgs)
    }
+   def toSourceString: String = s"Infix(${Sourceable(delim)}, ${Sourceable(impl)}, ${Sourceable(expl)}, ${Sourceable(assoc)})"
 }
 
 /** delimiter after the (explicit) arguments */
 case class Postfix(delim: Delimiter, impl: Int, expl: Int) extends SimpleFixity {
    lazy val markers = argsWithOp(expl)
    def asString = ("postfix", simpleArgs)
+   def toSourceString: String = s"Postfix(${Sourceable(delim)}, ${Sourceable(impl)}, ${Sourceable(expl)})"
 }
 
 /** delimiter followed by first and second (explicit) argument with . in between
@@ -100,6 +104,7 @@ case class Bindfix(delim: Delimiter, impl: Int, expl: Int, assoc: Boolean) exten
       val assocString = if (assoc) "-assoc" else ""
       ("bindfix"+assocString, simpleArgs)
    }
+   def toSourceString: String = s"Bindfix(${Sourceable(delim)}, ${Sourceable(impl)}, ${Sourceable(expl)}, ${Sourceable(assoc)})"
 }
 
 /**

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/notations/Precedence.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/notations/Precedence.scala
@@ -1,11 +1,12 @@
 package info.kwarc.mmt.api.notations
 
 import info.kwarc.mmt.api._
+import info.kwarc.mmt.api.utils.Sourceable
 
 /**
  * InfInt: integers with positive and negative infinity
 */
-sealed abstract class InfInt(s: String) extends scala.math.Ordered[InfInt] {
+sealed abstract class InfInt(s: String) extends scala.math.Ordered[InfInt] with Sourceable {
 
    /**
     * sum
@@ -49,14 +50,17 @@ case class Finite(ones : Int) extends InfInt(ones.toString) {
       case Infinite => -1
       case _ => 1
    }
+   def toSourceString: String = s"InfInt(${Sourceable(ones)})"
 }
 /** positively infinite InfInt */
 case object Infinite extends InfInt("infinity") {
   def compare(that: InfInt) = if (that == Infinite) 0 else 1
+  def toSourceString: String = "Infinite"
 }
 /** positively infinite InfInt */
 case object NegInfinite extends InfInt("-infinity") {
   def compare(that: InfInt) = if (that == NegInfinite) 0 else -1
+  def toSourceString: String = "NegInfinite"
 }
 /** helper object for InfInts */
 object InfInt {
@@ -75,7 +79,7 @@ object InfInt {
  * @param p the precedence, smaller precedence means weaker binding
  * @param loseTie tie-breaking flag for comparisons
 */
-sealed case class Precedence(prec : InfInt, loseTie : Boolean) extends scala.math.Ordered[Precedence] {
+sealed case class Precedence(prec : InfInt, loseTie : Boolean) extends scala.math.Ordered[Precedence] with Sourceable {
    def weaken = Precedence(prec, true)
    /**
     * irreflexive comparison
@@ -87,6 +91,7 @@ sealed case class Precedence(prec : InfInt, loseTie : Boolean) extends scala.mat
       else 1
    def +(i: Int) = Precedence(prec+i, loseTie)
    override def toString = prec.toString + (if (loseTie) "*" else "")
+   def toSourceString: String = s"Precedence(${Sourceable(prec)}, ${Sourceable(loseTie)})"
 }
 
 /** helper object for precedences */

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/objects/Context.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/objects/Context.scala
@@ -71,6 +71,13 @@ case class VarDecl(name : LocalName, feature: Option[String], tp : Option[Term],
           new DerivedDeclaration(home, n, f, TermContainer(tp), NotationContainer(not))
      }
    }
+
+   def toSourceString: String = s"VarDecl(" +
+      s"${Sourceable(name)}, " +
+      s"${Sourceable(feature)}, " +
+      s"${Sourceable(tp)}, " +
+      s"${Sourceable(df)}, " +
+      s"${Sourceable(not)})"
 }
 
 /** use this to create apply/unapply functions for variable declarations for a specific feature */
@@ -288,6 +295,8 @@ case class Context(variables : VarDecl*) extends Obj with ElementContainer[VarDe
           d
       }
    }
+
+   def toSourceString: String = s"Context(${variables.map(v => Sourceable(v)).mkString(", ")})"
 }
 
 /** a case in a substitution */		
@@ -304,6 +313,7 @@ case class Sub(name : LocalName, target : Term) extends Obj {
    def toCMLQVars(implicit qvars: Context) : Node = <mi name={name.toPath}>{target.toCMLQVars}</mi>
    override def toString = name + ":=" + target.toString
    def head = None
+   def toSourceString: String = s"Context(${Sourceable(name)}, ${Sourceable(target)})"
 }
 
 object IncludeSub {
@@ -362,6 +372,7 @@ case class Substitution(subs : Sub*) extends Obj {
    def toCMLQVars(implicit qvars: Context) = asContext.toCMLQVars
    def head = None
    def isEmpty = subs.isEmpty
+   def toSourceString: String = s"Substitution(${subs.map(s => Sourceable(s)).mkString(", ")}})"
 }
 
 /** helper object */

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/objects/Obj.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/objects/Obj.scala
@@ -127,6 +127,7 @@ case class OMID(path: ContentPath) extends Term {
       //case thy % name => <om:OMS name={name.toPath}>{mdNode}{thy.toNode}</om:OMS>
    }
    def toCMLQVars(implicit qvars: Context) = <csymbol>{path.toPath}</csymbol>
+   def toSourceString: String = s"OMID(${Sourceable(path)})"
 }
 
 object OMS {
@@ -165,6 +166,7 @@ case class OMBINDC(binder : Term, context : Context, scopes: List[Term]) extends
      (Context(), binder) :: context.subobjects ::: scopes.map(s => (context, s))
    }
    def toCMLQVars(implicit qvars: Context) = <apply>{binder.toCMLQVars}{context.map(_.toCMLQVars)}{scopes.map(_.toCMLQVars)}</apply>
+   def toSourceString: String = s"OMBINDC(${Sourceable(binder)}, ${Sourceable(context)}, ${Sourceable(scopes)})"
 }
 
 /**
@@ -195,6 +197,7 @@ case class OMA(fun : Term, args : List[Term]) extends Term {
    private[objects] lazy val freeVars_ = fun.freeVars_ ::: args.flatMap(_.freeVars_)
    def subobjects = ComplexTerm.subobjects(this) getOrElse subobjectsNoContext(fun :: args)
    def toCMLQVars(implicit qvars: Context) = <apply>{fun.toCMLQVars}{args.map(_.toCMLQVars)}</apply>
+   def toSourceString: String = s"OMA(${Sourceable(fun)}, ${Sourceable(args)})"
 }
 
 /**
@@ -240,6 +243,7 @@ case class OMV(name : LocalName) extends Term {
    def toCMLQVars(implicit qvars: Context) =
       if (qvars.isDeclared(name)) <mws:qvar xmlns:mws="http://www.mathweb.org/mws/ns">{name.toPath}</mws:qvar>
       else <ci>{name.toPath}</ci>
+   def toSourceString: String = s"OMV(${Sourceable(name)})"
 }
 
 /** helper object */
@@ -268,6 +272,7 @@ case class OMATTR(arg : Term, key : OMID, value : Term) extends Term {
    def subobjects = List(arg, key, value).map(s => (Context(), s))
    private[objects] def freeVars_ = arg.freeVars_ ::: value.freeVars_
    def toCMLQVars(implicit qvars: Context) = <apply><csymbol>OMATTR</csymbol>{arg.toCMLQVars}{key.toCMLQVars}{value.toCMLQVars}</apply>
+   def toSourceString: String = s"OMATTR(${Sourceable(arg)}, ${Sourceable(key)}, ${Sourceable(value)})"
 }
 
 /** apply/unapply methods for a list of attributions */
@@ -303,7 +308,8 @@ sealed trait OMLITTrait extends Term {
          (l.synType == m.synType) && l == l.rt.parse(m.value) 
       case (l: UnknownOMLIT, m: OMLIT) => m == l
       case _ => false
-   } 
+   }
+
 }
 
 /**
@@ -317,6 +323,8 @@ sealed trait OMLITTrait extends Term {
 case class OMLIT(value: Any, rt: uom.RealizedType) extends Term with OMLITTrait {
    def synType = rt.synType
    override def toString = rt.semType.toString(value)
+   def toSourceString: String = s"UnknownOMLIT(${Sourceable(toString)}, ${Sourceable(synType)})" +
+      s"/*OMLIT(${Sourceable(value.toString)}, ${Sourceable(rt.getClass.getCanonicalName)}(${Sourceable(rt.toString)}))/*"
 }
 
 /** degenerate case of OMLIT when no RealizedType was known to parse a literal
@@ -335,6 +343,8 @@ case class UnknownOMLIT(value: String, synType: Term) extends Term with OMLITTra
        rule.parse(value).from(this)
      }
    }
+
+   def toSourceString: String = s"UnknownOMLIT(${Sourceable(toString)}, ${Sourceable(synType)})"
 }
 
 /**
@@ -348,6 +358,7 @@ case class OMFOREIGN(node : Node) extends Term {
    private[objects] def freeVars_ = Nil
    def subobjects = Nil
    def toCMLQVars(implicit qvars: Context) = <apply><csymbol>OMFOREIGN</csymbol>{Node}</apply>
+   def toSourceString: String = s"OMFOREIGN(${Sourceable(node)})"
 }
 
 
@@ -371,6 +382,7 @@ case class OMSemiFormal(tokens: List[SemiFormalObject]) extends Term with SemiFo
       subobjectsNoContext(terms)
    }
    def toCMLQVars(implicit qvars: Context) = <apply><csymbol>OMSemiFormal</csymbol>{tokens.map(_.toCMLQVars)}</apply>
+   def toSourceString: String = s"OMSemiFormal(${Sourceable(tokens)})"
 }
 
 object OMSemiFormal {
@@ -390,6 +402,7 @@ case class OML(name: LocalName, tp: Option[Term], df: Option[Term], nt: Option[T
     def substitute(sub: Substitution)(implicit sa: SubstitutionApplier) = OML(name, tp map (_ ^^ sub), df map (_ ^^ sub),nt,featureOpt)
     def toCMLQVars(implicit qvars: Context) = <label>{vd.toCMLQVars}</label>
     def toNode = vd.toNode.copy(label = "OML")
+    def toSourceString: String = s"OML(${Sourceable(name)}, ${Sourceable(tp)}, ${Sourceable(df)}, ${Sourceable(nt)}, ${Sourceable(featureOpt)})"
 }
 
 case object OML {

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/objects/SemiFormal.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/objects/SemiFormal.scala
@@ -1,8 +1,9 @@
 package info.kwarc.mmt.api.objects
 import info.kwarc.mmt.api._
+import info.kwarc.mmt.api.utils.Sourceable
 import presentation._
 
-trait SemiFormalObject extends Content {
+trait SemiFormalObject extends Content with Sourceable {
    def freeVars : List[LocalName]
    def governingPath = None
    def toCMLQVars(implicit qvars: Context) : scala.xml.Node
@@ -13,18 +14,21 @@ case class Text(format: String, obj: String) extends SemiFormalObject {
    override def toString = "\"" + obj + "\""
    def freeVars : List[LocalName] = Nil
    def toCMLQVars(implicit qvars: Context) = <mtext format={format}>{scala.xml.PCData(obj)}</mtext>
+   def toSourceString: String = s"Text(${Sourceable(format)}, ${Sourceable(obj)})"
 }
 case class XMLNode(obj: scala.xml.Node) extends SemiFormalObject {
    def toNode = <om:node>{obj}</om:node>
    override def toString = obj.toString
    def freeVars : List[LocalName] = Nil
    def toCMLQVars(implicit qvars: Context) = obj
+   def toSourceString: String = s"XMLNode(${Sourceable(obj)})"
 }
 case class Formal(obj: Term) extends SemiFormalObject {
    def toNode = obj.toNode
    override def toString = obj.toString
    def freeVars : List[LocalName] = obj.freeVars_
    def toCMLQVars(implicit qvars: Context) = obj.toCMLQVars
+   def toSourceString: String = s"Formal(${Sourceable(obj)})"
 }
 
 trait SemiFormalObjectList {

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryResult.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryResult.scala
@@ -2,18 +2,21 @@ package info.kwarc.mmt.api.ontology
 
 import info.kwarc.mmt.api.{NamespaceMap, ParseError, Path}
 import info.kwarc.mmt.api.objects.Obj
-import info.kwarc.mmt.api.utils.xml
+import info.kwarc.mmt.api.utils.{Sourceable, SafeSourceableType, xml}
 
 import scala.collection.mutable.HashSet
 import scala.xml.Node
-
 import scala.language.implicitConversions
 
 
 /** a trait for all concrete data types that can be returned by queries; atomic types are paths and objects */
-trait BaseType
-case class XMLValue(node: scala.xml.Node) extends BaseType
-case class StringValue(string: String) extends BaseType
+trait BaseType extends Sourceable
+case class XMLValue(node: scala.xml.Node) extends BaseType {
+  def toSourceString: String = s"XMLValue(${Sourceable(node)})"
+}
+case class StringValue(string: String) extends BaseType {
+  def toSourceString: String = s"StringValue(${Sourceable(string)})"
+}
 
 object BaseType {
   /**

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/utils/Sourceable.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/utils/Sourceable.scala
@@ -1,0 +1,90 @@
+package info.kwarc.mmt.api.utils
+
+import scala.xml.Node
+
+/** data structure for everything that can be turned into a scala-compatible source string */
+trait Sourceable {
+  /** turns this object into a string that can be parsed by scala */
+  def toSourceString: String
+}
+
+/** helper class for requirement that anything which can be safely sourced */
+sealed trait SafeSourceableType[-T] {
+  def toSource(member : T) : String
+}
+
+object SafeSourceableType {
+
+  /** a sourceable itself can be safely turned into a source string */
+  implicit object SourceableType extends SafeSourceableType[Sourceable] {
+    def toSource(member : Sourceable) : String = member.toSourceString
+  }
+
+
+  // XML Node
+  implicit object NodeType extends SafeSourceableType[Node] {
+    def toSource(member : Node) : String = s"scala.xml.XML.loadString(${StringType.toSource(member.toString)})"
+  }
+
+  // Strings and Characters
+  implicit object StringType extends SafeSourceableType[String] {
+    def toSource(member: String): String =
+      if(member.contains("\n")){
+        "\"\"\"" + member.toString + "\"\"\""
+      } else {
+        "\"" + StandardStringEscaping(member) + "\""
+      }
+  }
+  implicit object CharType extends SafeSourceableType[Char] {
+    def toSource(member: Char): String = s"'$member'"
+  }
+
+  // Boolean
+  implicit object BooleanType extends SafeSourceableType[Boolean] {
+    def toSource(member: Boolean): String = member.toString
+  }
+
+  // Numeric Types
+  implicit object ByteType extends SafeSourceableType[Byte] {
+    def toSource(member: Byte): String = s"${IntType.toSource(member.toInt)}.toByte"
+  }
+
+  implicit object ShortType extends SafeSourceableType[Short] {
+    def toSource(member: Short): String = s"${StringType.toSource(member.toString)}.toShort"
+  }
+  implicit object IntType extends SafeSourceableType[Int] {
+    def toSource(member: Int): String = s"${StringType.toSource(member.toString)}.toInt"
+  }
+  implicit object LongType extends SafeSourceableType[Long] {
+    def toSource(member: Long): String = s"${StringType.toSource(member.toString)}.toLong"
+  }
+  implicit object FloatType extends SafeSourceableType[Float] {
+    def toSource(member: Float): String = s"${StringType.toSource(member.toString)}.toFloat"
+  }
+  implicit object DoubleType extends SafeSourceableType[Double] {
+    def toSource(member: Double): String = s"${StringType.toSource(member.toString)}.toDouble"
+  }
+
+  // higher order types
+  implicit def ListType[T: SafeSourceableType] : SafeSourceableType[List[T]] = new SafeSourceableType[List[T]] {
+    override def toSource(member: List[T]): String = {
+      val evidence = implicitly[SafeSourceableType[T]]
+      member.map(evidence.toSource).mkString(",")
+    }
+  }
+
+  implicit def OptionType[T: SafeSourceableType] : SafeSourceableType[Option[T]] = new SafeSourceableType[Option[T]] {
+    override def toSource(member: Option[T]): String = {
+      val evidence = implicitly[SafeSourceableType[T]]
+      member.map(e => s"Some(${evidence.toSource(e)})").getOrElse("None")
+    }
+  }
+}
+
+
+object Sourceable {
+  def apply[T](s : T)(implicit evidence: SafeSourceableType[T]) : Sourceable = new Sourceable {
+    override def toSourceString: String = evidence.toSource(s)
+    override def toString: String = toSourceString
+  }
+}

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/utils/URI.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/utils/URI.scala
@@ -12,7 +12,7 @@ case class URI(scheme: Option[String],
                path: List[String] = Nil,
                private val abs: Boolean = false,
                query: Option[String] = None,
-               fragment: Option[String] = None) {
+               fragment: Option[String] = None) extends Sourceable {
   private def isIllegal = (!abs && path.nonEmpty && authority.isDefined) || (!abs && path.startsWith(List("")))
   if (isIllegal) throw ImplementationError("illegal URI: " + this)
   /** true if the path is absolute; automatically set to true if scheme or authority are present */
@@ -129,6 +129,14 @@ case class URI(scheme: Option[String],
 
   private def mkS(p: String, s: Option[String]) = s.map(p+_).getOrElse("")
   override def toString: String = scheme.map(_+":").getOrElse("") + mkS("//", authority) + pathAsString + mkS("?",query) + mkS("#",fragment)
+
+  def toSourceString: String = "URI(" +
+    s"${Sourceable(scheme)}, " +
+    s"${Sourceable(authority)}, " +
+    s"${Sourceable(path)}, " +
+    s"${Sourceable(abs)}, " +
+    s"${Sourceable(query)}, " +
+    s"${Sourceable(fragment)})"
 }
 
 object URI {


### PR DESCRIPTION
This commit adds a toSourceString() method to all objects inside of MMT.
It is supposed to turn an object into a string that is equivalent to the
scala source code of the object.

Objects importing this method implement a new Sourceable trait. The
trait comes together with a type-safe application to all objects. 

/cc @florian-rabe @Jazzpirate 