### PR TITLE
Update build.sbt

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -2,11 +2,16 @@ import PostProcessApi._
 import sbt.Keys._
 import sbtunidoc.Plugin.UnidocKeys.unidoc
 
+// global configuration options
+// shared amongst the basic target and all the other ones
+val genericScalaVersion = "2.11.8"
+val genericScalaCOptions = Seq("-deprecation", "-Xmax-classfile-name", "128")
+
+// setup scala options
 publish := {}
+scalaVersion := genericScalaVersion
+scalacOptions := genericScalaCOptions
 
-scalaVersion := "2.11.8"
-
-scalacOptions := Seq("-deprecation")
 
 // = generation of API documentation
 
@@ -62,7 +67,8 @@ val deployFull =
 def commonSettings(nameStr: String) = Seq(
   organization := "info.kwarc.mmt",
   version := "1.0.1",
-  scalaVersion := "2.11.7",
+  scalaVersion := genericScalaVersion,
+  scalacOptions:= genericScalaCOptions,
   name := nameStr,
   sourcesInBase := false,
   libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test",


### PR DESCRIPTION
Previously, the `build.sbt` file used different version of scala amongst projects. Furthermore, several configured scalac options were not passed to all projects. Additionally, due to length of class names, there were compilation problems on file systems which did not allow longer file names.

This commit update the `build.sbt` file to fix these problems. It adds two new variables to the top of the file, describing the scala version to use and the scala compiler options to pass to each project.
Furthermore, the changes ensure that these variables are passed to all projects consistently.

To fix the problem of compilation on file systems which do not support long file names, we also set the `-Xmax-classfile-name` compiler option.