### PR TITLE
Structure Travis Tests & Fix Regression in build.sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,52 @@
-# sudo: required
 dist: trusty
 language: scala
 scala: 2.11.8
 
-#before_install:
-# - sudo apt-get update -qq
-# - sudo apt-get install -qq graphviz smlnj jedit xvfb
-script:
- - bash scripts/travis/deploy_doc.sh
- - cd src
- - sbt compile
- - sbt deployFull
- - sbt test
- # - git clone http://gl.mathhub.info/meta/inf.git
- # - inf/config/MMT/testScripts/testUrtheories.sh
- # - inf/config/MMT/testScripts/testExamples.sh
- # - inf/config/MMT/testScripts/testSms.sh
- # - inf/config/MMT/testScripts/testTeX.sh
- # - cp inf/config/MMT/cf95c94bae142eeed300a254d964f0bf $HOME/.subversion/auth/svn.ssl.server/
- # - inf/config/MMT/setupTwelf.sh > /dev/null
- # - export PATH=/usr/local/share/twelf-mod/bin:$PATH
- # - inf/config/MMT/testScripts/testLATIN.sh
- # - inf/config/MMT/testScripts/testJEdit.sh
+# define 'stages' of our build process
+stages:
+  - name: Build.sbt
+  - name: CodeCheck
+  - name: DeployCheck
+  - name: Test
+  - name: Deploy
+    if: branch = master
+
+# define several 'jobs' for each stage
+# within a single stage jobs are run in parallel, each in their own environment
+# HACK: We use the INFO variable to display some information in the Travis UI
+jobs:
+  include:
+    # check that we can load build.sbt loads
+    - stage: Build.sbt
+      script: cd src && (cat /dev/null | sbt exit)
+      env: INFO='Check that build.sbt loads'
+
+    # check that the sources compile, print all the scalastyle warnings
+    - stage: CodeCheck
+      script: cd src && (cat /dev/null | sbt compile)
+      env: INFO='Check that the code compiles'
+    - script: cd src && (cat /dev/null | sbt scalastyle)
+      env: INFO='Print scalastyle violations'
+
+    # check that the 'apidoc', 'deploy' and 'deployFull' targets work
+    - stage: DeployCheck
+      script: cd src && (cat /dev/null | sbt deploy) && [[ -f "../deploy/mmt.jar" ]]
+      env: INFO='Check mmt.jar generation using `sbt deploy`'
+    - script: cd src && (cat /dev/null | sbt deployFull) && [[ -f "../deploy/mmt.jar" ]]
+      env: INFO='Check mmt.jar generation using `sbt deployFull`'
+    - script: cd src && (cat /dev/null | sbt apidoc) && [[ -d "../apidoc" ]]
+      env: INFO='Check that apidoc generation works'
+
+    # check that our own tests work
+    # TODO: Split into unit tests (partial) and test/general tests
+    - stage: Test
+      script: cd src && (cat /dev/null | sbt test)
+      env: INFO='Run MMT Tests'
+
+    # deploy the api documentation
+    - stage: Deploy
+      script: bash scripts/travis/deploy_doc.sh
+      env: INFO='Auto-deploy API documentation'
 
 env:
   global:


### PR DESCRIPTION
Previously the travis build process was a sequential list of commands that was run. This was very unstructured, and a failing test provided little information about what was going wrong.

This PR structures the travis build process by introducing different stages. Build stages are a beta feature of Travis CI that allows to specify a sequential list of stages, each containing a set of jobs that is run in parallel.

If a stage fails, one can immediately see which stage has caused the error, and subsequent tests are not run: 
![Stage has failed](https://user-images.githubusercontent.com/2923242/33855197-8120186e-dec4-11e7-9b67-f914ec26c952.png)

Succeeded stages also show up nicely:
![Stage has succeeded](https://user-images.githubusercontent.com/2923242/33855483-4f497aa0-dec5-11e7-8111-0439f7532c0d.png)

We define five stages:
1. `build.sbt` that checks if the sbt build definition is valid;
2. `CodeCheck` that checks if the code compiles and also prints scalastyle warnings;
3. `DeployCheck` that checks if the fatjar generation and API documentation generation works;
4. `Test` that uses the tests defined in scala code; and
5. `Deploy` which auto-generates the API documentation and deploys it to https://uniformal.github.io/apidoc/

Stages 1 - 4 are set to be run in all situations, stage 5 will only be run on the master branch. 



The cleaned up travis build process showed that two parts of build.sbt were broken during recent commits. The API documentation failed to build, and the `deployFull` task did not generate a fat mmt.jar.

This PR fixes the issues by introducing appropriate changes to `build.sbt`. To fix the first issue, the sbt-unidoc plugin is enabled for the root sbt project instead of the mmt project. To fix the second issue, we ensure that the `deployFull` task depends on the `deployFull` task.