### PR TITLE
Bump Scala Version to 2.11.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: scala
-scala: 2.11.8
+scala: 2.11.12
 
 # define 'stages' of our build process
 stages:

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -12,7 +12,7 @@ organization in ThisBuild := "info.kwarc.mmt"
 // =================================
 // GLOBAL SETTINGS
 // =================================
-scalaVersion in Global := "2.11.8"
+scalaVersion in Global := "2.11.12"
 scalacOptions in Global := Seq("-feature", "-deprecation", "-Xmax-classfile-name", "128")
 
 parallelExecution in ThisBuild := false


### PR DESCRIPTION
This commit makes a PATCH update from Scala 2.11.8 to 2.11.12. 
According to the [release notes](https://github.com/scala/scala/releases/tag/v2.11.12) this provides basic scala support for Java 9. 