### PR TITLE
Replace sun.misc.BASE64* classes (fixes #260)

### DIFF
--- a/src/mmt-odk/src/info/kwarc/mmt/odk/OpenMath/OMCoding.scala
+++ b/src/mmt-odk/src/info/kwarc/mmt/odk/OpenMath/OMCoding.scala
@@ -1,7 +1,5 @@
 package info.kwarc.mmt.odk.OpenMath
 
-import scala.xml.{Node, Text, TextBuffer, Elem, Attribute, Null}
-
 /**
   * Represents an OpenMath Coding
   * @tparam T Type this OpenMath Coding codes from / to
@@ -73,6 +71,6 @@ object OMCoding {
     java.lang.Double.longBitsToDouble(longHexInvertEndianess)
   }
 
-  def bytes2Hex(bytes : List[Byte]) : String = new sun.misc.BASE64Encoder().encode(bytes.toArray)
-  def hex2Bytes(hex : String) : List[Byte] = new sun.misc.BASE64Decoder().decodeBuffer(hex).toList
+  def bytes2Hex(bytes: List[Byte]): String = java.util.Base64.getEncoder.encodeToString(bytes.toArray)
+  def hex2Bytes(hex: String): List[Byte] = java.util.Base64.getDecoder.decode(hex).toList
 }


### PR DESCRIPTION
The mmt-odk project used the `sun.misc.BASE64Encoder` and `sun.misc.BASE64Decoder` classes, which are only<F5> available up toJava 8. This lead to compilation problems in Java 9.

This PR fixes the issue by replacing the classes with near-drop-in-replacements from `java.util.Base64`. This means that we have to drop support for Java <= 7 for our OpenMath implementation.