### PR TITLE
Travis Testing For Initial Java 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,211 @@
-dist: trusty
-language: scala
-scala: 2.11.12
 
-# define 'stages' of our build process
-stages:
-  - name: Build.sbt
-  - name: CodeCheck
-  - name: DeployCheck
-  - name: Test
-  - name: Deploy
-    if: branch = master
 
-# define several 'jobs' for each stage
-# within a single stage jobs are run in parallel, each in their own environment
-# HACK: We use the INFO variable to display some information in the Travis UI
-jobs:
-  include:
-    # check that we can load build.sbt loads
-    - stage: Build.sbt
-      script: cd src && (cat /dev/null | sbt exit)
-      env: INFO='Check that build.sbt loads'
+# +===============================================================+
+# |THIS FILE HAS BEEN AUTO-GENERATED USING `sbt genTravisYML`     |
+# |ANY CHANGES WILL BE OVERWRITTEN                                |
+# +===============================================================+
 
-    # check that the sources compile, print all the scalastyle warnings
-    - stage: CodeCheck
-      script: cd src && (cat /dev/null | sbt compile)
-      env: INFO='Check that the code compiles'
-    - script: cd src && (cat /dev/null | sbt scalastyle)
-      env: INFO='Print scalastyle violations'
+# these values were configured in src/project/prefix.travis.yml
 
-    # check that the 'apidoc', 'deploy' and 'deployFull' targets work
-    - stage: DeployCheck
-      script: cd src && (cat /dev/null | sbt deploy) && [[ -f "../deploy/mmt.jar" ]]
-      env: INFO='Check mmt.jar generation using `sbt deploy`'
-    - script: cd src && (cat /dev/null | sbt deployFull) && [[ -f "../deploy/mmt.jar" ]]
-      env: INFO='Check mmt.jar generation using `sbt deployFull`'
-    - script: cd src && (cat /dev/null | sbt apidoc) && [[ -d "../apidoc" ]]
-      env: INFO='Check that apidoc generation works'
-
-    # check that our own tests work
-    # TODO: Split into unit tests (partial) and test/general tests
-    - stage: Test
-      script: cd src && (cat /dev/null | sbt test)
-      env: INFO='Run MMT Tests'
-
-    # deploy the api documentation
-    - stage: Deploy
-      script: bash scripts/travis/deploy_doc.sh
-      env: INFO='Auto-deploy API documentation'
-
+# configuration for deploy
 env:
   global:
   - ENCRYPTION_LABEL: "25a07036478c"
   - COMMIT_AUTHOR_EMAIL: "tkw01536@gmail.com"
+
+# using trusty and scala
+dist: trusty
+language: scala
+
+# speed up cloning of the git repository
+# we only need a clone depth of '1'
+git:
+  depth: 1
+
+
+
+# everything below this line is automatically generated using the configuration in src/travis.sbt
+stages: 
+  - name: build.sbt
+  - name: CodeCheck
+  - name: DeployCheck
+  - name: test
+  - name: deploy
+    if: branch = master
+jobs: 
+  include: 
+    # check that build.sbt loads
+    - stage: build.sbt
+      scala: 2.11.12
+      script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 exit)"
+      jdk: openjdk7
+      env: 
+        - INFO='Check that build.sbt loads'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 exit)"
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check that build.sbt loads'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 exit)"
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check that build.sbt loads'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 exit)"
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check that build.sbt loads'
+    # check that the code conforms to standards
+    - stage: CodeCheck
+      scala: 2.11.12
+      script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 compile)"
+      jdk: openjdk7
+      env: 
+        - INFO='Check that the code compiles'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 compile)"
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check that the code compiles'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 compile)"
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check that the code compiles'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 compile)"
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check that the code compiles'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 scalastyle)"
+      scala: 2.11.12
+      jdk: openjdk7
+      env: 
+        - INFO='Print scalastyle violations'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 scalastyle)"
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Print scalastyle violations'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 scalastyle)"
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Print scalastyle violations'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 scalastyle)"
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Print scalastyle violations'
+    # check that the 'apidoc', 'deploy' 'genTravisYML' and 'deployFull' targets work
+    - stage: DeployCheck
+      scala: 2.11.12
+      script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deploy) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      jdk: openjdk7
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deploy`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deploy) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deploy`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deploy) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deploy`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deploy) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deploy`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deployFull) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: openjdk7
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deployfull`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deployFull) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deployfull`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deployFull) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deployfull`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 deployFull) && cd .. && [[ -f "deploy/mmt.jar" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check mmt.jar generation using `sbt deployfull`'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 apidoc) && cd .. && [[ -d "apidoc" ]]'
+      scala: 2.11.12
+      jdk: openjdk7
+      env: 
+        - INFO='Check that apidoc generation works'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 apidoc) && cd .. && [[ -d "apidoc" ]]'
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check that apidoc generation works'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 apidoc) && cd .. && [[ -d "apidoc" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check that apidoc generation works'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 apidoc) && cd .. && [[ -d "apidoc" ]]'
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check that apidoc generation works'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 genTravisYML) && cd .. && (git diff --quiet --exit-code ".travis.yml")'
+      scala: 2.11.12
+      jdk: openjdk7
+      env: 
+        - INFO='Check that `sbt genTravisYML` has been run'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 genTravisYML) && cd .. && (git diff --quiet --exit-code ".travis.yml")'
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Check that `sbt genTravisYML` has been run'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 genTravisYML) && cd .. && (git diff --quiet --exit-code ".travis.yml")'
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Check that `sbt genTravisYML` has been run'
+    - script: 'cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 genTravisYML) && cd .. && (git diff --quiet --exit-code ".travis.yml")'
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Check that `sbt genTravisYML` has been run'
+    # check that our own tests work
+    - stage: test
+      scala: 2.11.12
+      script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 test)"
+      jdk: openjdk7
+      env: 
+        - INFO='Run MMT Tests'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 test)"
+      scala: 2.11.12
+      jdk: openjdk8
+      env: 
+        - INFO='Run MMT Tests'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 test)"
+      scala: 2.11.12
+      jdk: oraclejdk8
+      env: 
+        - INFO='Run MMT Tests'
+    - script: "cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 test)"
+      scala: 2.11.12
+      jdk: oraclejdk9
+      env: 
+        - INFO='Run MMT Tests'
+    # deploy the api documentation
+    - stage: deploy
+      scala: 2.11.12
+      script: bash scripts/travis/deploy_doc.sh
+      jdk: openjdk8
+      env: 
+        - "INFO='Auto-deploy API documentation'"

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -18,7 +18,6 @@ scalacOptions in Global := Seq("-feature", "-deprecation", "-Xmax-classfile-name
 parallelExecution in ThisBuild := false
 javaOptions in ThisBuild ++= Seq("-Xmx1g")
 
-
 connectInput in run := true
 mainClass in Compile := Some("info.kwarc.mmt.api.frontend.Run")
 
@@ -169,7 +168,7 @@ lazy val concepts = (project in file("concept-browser")).
   settings(mmtProjectsSettings("concept-browser"): _*).
   settings(
     libraryDependencies ++= Seq(
-      "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2"
+      "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2.1"
     ),
     unmanagedJars in Compile += Utils.lib.toJava / "tiscaf.jar",
     unmanagedJars in Compile += Utils.lib.toJava / "scala-xml.jar"

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -91,19 +91,33 @@ def mmtProjectsSettings(nameStr: String) = commonSettings(nameStr) ++ Seq(
 )
 
 // =================================
+// EXCLUDED PROJECTS
+// =================================
+import VersionSpecificProject._
+lazy val excludedProjects = {
+  Exclusions(guidedTours, metamath)
+    .java7(repl, odk)
+    .java9(concepts)
+}
+
+// =================================
 // Main MMT Projects
 // =================================
 lazy val src = (project in file(".")).
   enablePlugins(ScalaUnidocPlugin).
+  exclusions(excludedProjects).
   aggregate(
-    mmt, api,
-    leo, lf, concepts, tptp, owl, mizar, frameit, mathscheme, pvs, metamath, tps, imps, odk, specware, stex, webEdit, planetary, interviews, latex, openmath, oeis, repl,
-    tiscaf, lfcatalog,
-    jedit
-)
+      mmt, api,
+      leo, lf, concepts, tptp, owl, mizar, frameit, mathscheme, pvs, metamath, tps, imps, odk, specware, stex, webEdit, planetary, interviews, latex, openmath, oeis, repl,
+      tiscaf, lfcatalog,
+      jedit
+  ).settings(
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := excludedProjects.toFilter
+  )
+
 
 lazy val mmt = (project in file("mmt")).
-  enablePlugins(ScalaUnidocPlugin).
+  exclusions(excludedProjects).
   dependsOn(tptp, stex, pvs, specware, webEdit, oeis, odk, jedit, latex, openmath, imps, repl, concepts, interviews).
   settings(mmtProjectsSettings("mmt"): _*).
   settings(
@@ -168,7 +182,7 @@ lazy val concepts = (project in file("concept-browser")).
   settings(mmtProjectsSettings("concept-browser"): _*).
   settings(
     libraryDependencies ++= Seq(
-      "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2.1"
+      "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2"
     ),
     unmanagedJars in Compile += Utils.lib.toJava / "tiscaf.jar",
     unmanagedJars in Compile += Utils.lib.toJava / "scala-xml.jar"
@@ -204,8 +218,9 @@ lazy val pvs = (project in file("mmt-pvs")).
   dependsOn(api, lf).
   settings(mmtProjectsSettings("mmt-pvs"): _*)
 
+lazy val mmscala = RootProject(uri("https://github.com/digama0/mm-scala.git#master"))
 lazy val metamath = (project in file("mmt-metamath")).
-  dependsOn(api, lf, RootProject(uri("https://github.com/digama0/mm-scala.git#master"))).
+  dependsOn(api, lf, mmscala).
   settings(mmtProjectsSettings("mmt-metamath"): _*)
 
 lazy val tps = (project in file("mmt-tps")).
@@ -228,12 +243,9 @@ lazy val stex = (project in file("mmt-stex")).
   dependsOn(api).
   settings(mmtProjectsSettings("mmt-stex"): _*)
 
-/*
 lazy val guidedTours = (project in file("mmt-guidedTours")).
   dependsOn(api).
   settings(mmtProjectsSettings("mmt-guidedTours"): _*)
-*/
-
 
 lazy val webEdit = (project in file("mmt-webEdit")).
   dependsOn(stex).

--- a/src/project/Utils.scala
+++ b/src/project/Utils.scala
@@ -135,5 +135,4 @@ object Utils {
     if (path.exists && path.isDirectory) delRecursive(path)
     else log.warn("ignoring missing directory: " + path)
   }
-
 }

--- a/src/project/VersionSpecificProject.scala
+++ b/src/project/VersionSpecificProject.scala
@@ -1,0 +1,44 @@
+import scala.language.implicitConversions
+import sbt._
+
+
+case class VersionSpecificProject(project: Project, excludes: Exclusions) {
+  def exclusions(newExclusions : Exclusions) : VersionSpecificProject = VersionSpecificProject(project, newExclusions)
+
+  def aggregate(projects: Project*) : Project = {
+    def toProjectReference(p : Project) : ProjectReference = p
+    project
+      .aggregate(excludes(projects.toList).map(toProjectReference(_)) :_*)
+  }
+
+  def dependsOn(projects: Project*) : Project = {
+    def toClassPathDep(p: Project) : ClasspathDep[ProjectReference] = p
+    project.dependsOn(excludes(projects.toList).map(toClassPathDep(_)) :_*)
+  }
+}
+
+object VersionSpecificProject {
+  implicit def fromProject(project: Project) : VersionSpecificProject = VersionSpecificProject(project, Exclusions())
+  implicit def toProject(vProject: VersionSpecificProject): Project = vProject.project
+}
+
+case class Exclusions(lst: Project*) {
+  private def javaVersion(versions: List[String], exclusions: List[Project]) : Exclusions = {
+    val theVersion = System.getProperty("java.version")
+    if(versions.exists(v => theVersion.startsWith(s"$v."))){:::(exclusions)} else this
+  }
+  def java7(exclusions: Project*): Exclusions = javaVersion(List("1.7", "7"), exclusions.toList)
+  def java8(exclusions: Project*): Exclusions = javaVersion(List("1.8", "8"), exclusions.toList)
+  def java9(exclusions: Project*): Exclusions = javaVersion(List("1.9", "9"), exclusions.toList)
+
+  def :::(lst2: List[Project]) = Exclusions(lst.toList ::: lst2 : _*)
+  def :::(other: Exclusions) = Exclusions(lst.toList ::: other.lst.toList :_*)
+
+  def toFilter : ScopeFilter.ProjectFilter = {
+    def toProjectReference(p : Project) : ProjectReference = p
+    inAnyProject -- inProjects(lst.map(toProjectReference) :_*)
+  }
+
+  def excludes(project: Project) : Boolean = lst.contains(project)
+  def apply(projects: List[Project]) : List[Project] = projects.filterNot(this.excludes)
+}

--- a/src/project/prefix.travis.yml
+++ b/src/project/prefix.travis.yml
@@ -1,0 +1,31 @@
+## Any content in this file will be prepended to .travis.yml
+## Any lines starting with '##' will be ignored
+## ===============================================================
+## ===============================================================
+
+
+# +===============================================================+
+# |THIS FILE HAS BEEN AUTO-GENERATED USING `sbt genTravisYML`     |
+# |ANY CHANGES WILL BE OVERWRITTEN                                |
+# +===============================================================+
+
+# these values were configured in src/project/prefix.travis.yml
+
+# configuration for deploy
+env:
+  global:
+  - ENCRYPTION_LABEL: "25a07036478c"
+  - COMMIT_AUTHOR_EMAIL: "tkw01536@gmail.com"
+
+# using trusty and scala
+dist: trusty
+language: scala
+
+# speed up cloning of the git repository
+# we only need a clone depth of '1'
+git:
+  depth: 1
+
+
+
+# everything below this line is automatically generated using the configuration in src/travis.sbt

--- a/src/project/project.sbt
+++ b/src/project/project.sbt
@@ -1,0 +1,2 @@
+/* meta-build */
+scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")

--- a/src/project/project/build.properties
+++ b/src/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.2

--- a/src/project/src/main/scala/travis/Config.scala
+++ b/src/project/src/main/scala/travis/Config.scala
@@ -1,0 +1,21 @@
+package src.main.scala.travis
+
+import src.main.scala.yaml.{YAML, YAMLSequence, YAMLStructure}
+
+/**
+  * Represenmts
+  * @param globals
+  * @param stages
+  */
+case class Config(globals: MatrixKey[YAML]*)(stages: Stage*) {
+  def toYAML: YAMLStructure = {
+    val stagesDesc : YAMLSequence = stages.map(_.toStageDesc).map(YAMLSequence.from(_)).foldLeft(YAMLSequence.empty)( _ ++ _)
+    Map(
+      "stages" -> stagesDesc,
+      "jobs" -> YAMLStructure(Map(
+        "include" -> stages.map(_.toJobList(this)).foldLeft(YAMLSequence.empty)(_ ++ _)
+      ), None)
+    )
+  }
+  def serialize : String = toYAML.serialize
+}

--- a/src/project/src/main/scala/travis/Job.scala
+++ b/src/project/src/main/scala/travis/Job.scala
@@ -1,0 +1,23 @@
+package src.main.scala.travis
+
+import src.main.scala.yaml.{YAML, YAMLSequence, YAMLString, YAMLStructure}
+
+/**
+  * A single Job being run by travis
+  *
+  * @param description A short, human-readable, description of the job
+  * @param script A script to executed when running the job
+  * @param keys a set of keys that will be expanded in the build matrix
+  */
+case class Job(description: String, script: String)(keys: MatrixKey[YAML]*) {
+  lazy val defaults : MatrixMap = MatrixMap(
+    ScriptKey(script),
+    DescriptionKey(description)
+  )
+
+  /** expands this job into a concrete list [[MatrixMap]] assignments */
+  def expand(stage: Stage, config: Config): List[MatrixMap] = {
+    val withGlobals = MatrixKey.includeGlobals(keys.toList, config.globals.toList)
+    defaults ++ MatrixMap.expand(withGlobals)
+  }
+}

--- a/src/project/src/main/scala/travis/MatrixKey.scala
+++ b/src/project/src/main/scala/travis/MatrixKey.scala
@@ -1,0 +1,47 @@
+package src.main.scala.travis
+
+import src.main.scala.yaml._
+
+/**
+  * Represents a single configurable Travis CI Setting that can have multiple values to be expanded
+  *
+  * @param name name of the setting to be expanded
+  * @param value value to be stored in the YAML file
+  * @param expand Boolean indicating if this value should be expanded or not
+  * @tparam T [[YAML]] type of the value to be stored
+  */
+sealed abstract class MatrixKey[+T <: YAML](val name : String, val value: T, val expand: Boolean = true) {
+  /** returns a new [[MatrixKey]] of the same type that will never be expanded */
+  def static: MatrixKey[T] = new MatrixKey[T](name, value, false){}
+}
+
+object MatrixKey {
+  def includeGlobals(locals: List[MatrixKey[YAML]], globals: List[MatrixKey[YAML]]) : List[MatrixKey[YAML]] = {
+    globals.filterNot(gk => locals.exists(_.name == gk.name)) ::: locals
+  }
+}
+
+/** a set of environment variables to be set */
+case class Env(env: Map[String, String]) extends MatrixKey[YAMLStructure]("env", env.mapValues(YAMLString.fromString))
+
+/** the versions of the JDK being used */
+case class JDK(version: JDKVersion.Value) extends MatrixKey[YAMLString]("jdk", version.toString)
+object JDKVersion extends Enumeration {
+  val IBMJava8 : Value = Value("ibmjava8")
+
+  val OpenJDK6 : Value = Value("openjdk6")
+  val OpenJDK7 : Value = Value("openjdk7")
+  val OpenJDK8 : Value = Value("openjdk8")
+
+  val OracleJDK8 : Value = Value("oraclejdk8")
+  val OracleJDK9 : Value = Value("oraclejdk9")
+}
+
+/** the versions of Scala being used */
+case class Scala[YAMLString](version: String) extends MatrixKey("scala", YAMLString.fromString(version))
+
+/** internal matrix keys */
+sealed abstract class InternalMatrixKey[+T <: YAML](override val name: String, override val value: T) extends MatrixKey[T](name, value, false)
+private[travis] case class StageKey(stage : String) extends InternalMatrixKey[YAMLString]("stage", stage)
+private[travis] case class ScriptKey(script : String) extends InternalMatrixKey[YAMLString]("script", script)
+private[travis] case class DescriptionKey(info : String) extends InternalMatrixKey[YAMLSequence]("env", YAMLSequence.from(YAMLString.fromString("INFO='" + info + "'")))

--- a/src/project/src/main/scala/travis/MatrixMap.scala
+++ b/src/project/src/main/scala/travis/MatrixMap.scala
@@ -1,0 +1,70 @@
+package src.main.scala.travis
+
+import src.main.scala.yaml.{YAML, YAMLSequence, YAMLStructure}
+
+import scala.language.implicitConversions
+
+/** Represents an assignment of [[MatrixKey]]s to actual assignment */
+case class MatrixMap(values: List[MatrixKey[YAML]]) {
+  lazy val toMap : Map[String, YAML] = values.groupBy(_.name).map(kv=>(kv._1, kv._2.head.value))
+  lazy val toStructure: YAMLStructure = toMap
+
+  def ++ (key: MatrixKey[YAML]) : MatrixMap = MatrixMap(key :: values)
+  def ++ (map: MatrixMap) = MatrixMap(values ::: map.values)
+  def ++ (maps: List[MatrixMap]) : List[MatrixMap] = maps.map(++)
+}
+
+object MatrixMap {
+  def empty: MatrixMap = MatrixMap(Nil)
+  def apply(values: MatrixKey[YAML]*) : MatrixMap = apply(values.toList)
+
+  def toSequence(maps: List[MatrixMap]) : YAMLSequence = maps.map(_.toStructure)
+
+  /** expands a list of [[MatrixKey]]s  into a list of concrete [[MatrixMap]] assignments */
+  def expand(values: List[MatrixKey[YAML]]): List[MatrixMap] = {
+    // partition into keys that should and should not be expanded
+    val (matrixValues, staticValues) = values.partition(_.expand)
+
+    val nonExpanded = MatrixMap(staticValues)
+
+    val matrixArgs = matrixValues.groupBy(_.name).values.filter(_.nonEmpty).toList.sortBy(_.head.name)
+    val expanded : List[List[MatrixKey[YAML]]] = cartesianProduct(matrixArgs)
+
+    if(matrixArgs.nonEmpty) (if(matrixArgs.lengthCompare(1) == 0) expanded.transpose else expanded).map(MatrixMap(_) ++ nonExpanded) else List(nonExpanded)
+  }
+
+  /**
+    * Compute the cartesian product of a list of lists
+    * Adapted from https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists#Scala
+    */
+  private def cartesianProduct[T](lst: List[List[T]]): List[List[T]] = {
+
+    /**
+      * Prepend single element to all lists of list
+      * @param e single elemetn
+      * @param ll list of list
+      * @param a accumulator for tail recursive implementation
+      * @return list of lists with prepended element e
+      */
+    def pel(e: T,
+            ll: List[List[T]],
+            a: List[List[T]] = Nil): List[List[T]] =
+      ll match {
+        case Nil => a.reverse
+        case x :: xs => pel(e, xs, (e :: x) :: a )
+      }
+
+    lst match {
+      case Nil => Nil
+      case x :: Nil => List(x)
+      case x :: _ =>
+        x match {
+          case Nil => Nil
+          case _ =>
+            lst.par.foldRight(List(x))( (l, a) =>
+              l.flatMap(pel(_, a))
+            ).map(_.dropRight(x.size))
+        }
+    }
+  }
+}

--- a/src/project/src/main/scala/travis/Stage.scala
+++ b/src/project/src/main/scala/travis/Stage.scala
@@ -1,0 +1,24 @@
+package src.main.scala.travis
+
+import src.main.scala.yaml.{YAMLSequence, YAMLString, YAMLStructure}
+
+/**
+  * Represents a single stage of Travis Testing
+  * @param name the name of the current stage
+  * @param description a (human-readable) description of the current stage
+  * @param condition an (optional) condition to check when running the stage
+  * @param jobs the jobs this stage consists of
+  */
+case class Stage(name: String, description: String, condition: Option[String] = None)(jobs: Job*) {
+  /** expands this stage into a travis map representing the stage */
+  def toStageDesc: YAMLStructure = {
+    Map(("name", YAMLString.fromString(name))) ++ condition.map(c => Map(("if", YAMLString.fromString(c)))).getOrElse(Map())
+  }
+
+  /** expands this job into a concrete list of travis.yml maps representing the job */
+  def toJobList(config: Config): YAMLSequence = {
+    val jobList : List[MatrixMap] = jobs.flatMap(_.expand(this, config)).toList
+    val jobStructList : List[YAMLStructure] = ((jobList.head ++ StageKey(name)) :: jobList.tail).map(_.toStructure)
+    YAMLSequence.fromSequence(jobStructList).withComment(description).asInstanceOf[YAMLSequence]
+  }
+}

--- a/src/project/src/main/scala/yaml/YAML.scala
+++ b/src/project/src/main/scala/yaml/YAML.scala
@@ -1,0 +1,42 @@
+package src.main.scala.yaml
+
+import scala.language.postfixOps
+
+/** Implements a subset of YAML objects which can be easily serialized */
+sealed trait YAML {
+  val comment: Option[String]
+  private[yaml] def setComment(comment : Option[String]) : YAML
+  def withComment(comment: String) : YAML = setComment(Some(comment))
+  def dropComment : YAML = setComment(None)
+
+  def serialize: String
+  private[yaml] def serializeComment(prefix : String = "") : Option[String] = comment.map(YAML.serializeComment(_, prefix))
+  private[yaml] def serializeWith(prefix: String) : String = YAML.serializeWithPrefix(serialize, prefix)
+  private[yaml] def serializeAs(prefix: String) : String = prefix + serializeWith(prefix)
+}
+
+private[yaml] trait YAMLImplementation extends YAML
+
+object YAML {
+  def serializeWithPrefix(value: String, prefix: String) : String = {
+    val spacePrefix = " " * prefix.length
+
+    val lines : List[String] = value.split("\n").toList
+    if(lines.isEmpty) "" else (lines.head :: lines.tail.map(spacePrefix +)).mkString("\n")
+  }
+  def serializeComment(comment: String, prefix : String = "") : String = {
+    serializeWithPrefix(comment.split("\n").map("# " +).mkString("\n"), prefix)
+  }
+  def prefixComment[T <: YAML](obj: T, comment: Option[String]) : T = {
+    val newComment = obj.comment match {
+      case Some(c) => Some(comment.map(c + "\n" + _).getOrElse(c))
+      case None => comment
+    }
+    obj.setComment(newComment).asInstanceOf[T]
+  }
+}
+
+
+
+
+

--- a/src/project/src/main/scala/yaml/YAMLLiteral.scala
+++ b/src/project/src/main/scala/yaml/YAMLLiteral.scala
@@ -1,0 +1,41 @@
+package src.main.scala.yaml
+
+import scala.language.implicitConversions
+
+/** represents any literal value */
+sealed abstract class YAMLLiteral(val value: String, val comment: Option[String]) extends YAMLImplementation {
+  def serialize: String = if(comment.isDefined) s"$value ${YAML.serializeComment(comment.get, value + " ")}" else value
+}
+
+/** represents a string */
+case class YAMLString(s: String, override val comment: Option[String]) extends YAMLLiteral(YAMLString.serializeString(s), comment) {
+  def setComment(comment : Option[String]) : YAMLString = copy(comment = comment)
+}
+object YAMLString {
+  private[yaml] def serializeString(s: String) : String = {
+    lazy val hasBlackList = !List("-", "\n", ":", "[", ">", "{").exists(s.contains)
+    if (s.matches("^[A-Za-z_]+[A-Za-z0-9_]$") || hasBlackList) s else {
+      if(!s.contains("\"")) "\"" + s + "\"" else "'" + s + "'"
+    }
+  }
+  implicit def toString(ys: YAMLString) : String = ys.s
+  implicit def fromString(s: String) : YAMLString = YAMLString(s, None)
+}
+
+/** represents a number */
+case class YAMLNumber(d: Double, override val comment: Option[String]) extends YAMLLiteral(d.toString, comment) {
+  def setComment(comment : Option[String]) : YAMLNumber = copy(comment = comment)
+}
+object YAMLNumber {
+  implicit def toDouble(yn: YAMLNumber) : Double = yn.d
+  implicit def fromDouble(d : Double) : YAMLNumber = YAMLNumber(d, None)
+}
+
+/** represents a boolean */
+case class YAMLBoolean(b : Boolean, override val comment: Option[String]) extends YAMLLiteral(b.toString, comment) {
+  def setComment(comment : Option[String]) : YAMLBoolean = copy(comment = comment)
+}
+object YAMLBoolean {
+  implicit def toBoolean(yb: YAMLBoolean) : Boolean = yb.b
+  implicit def fromBoolean(b : Boolean) : YAMLBoolean = YAMLBoolean(b, None)
+}

--- a/src/project/src/main/scala/yaml/YAMLSequence.scala
+++ b/src/project/src/main/scala/yaml/YAMLSequence.scala
@@ -1,0 +1,40 @@
+package src.main.scala.yaml
+
+import scala.collection.mutable.ListBuffer
+
+import scala.language.implicitConversions
+import scala.language.postfixOps
+
+/** Represents a sequence of YAML objects */
+case class YAMLSequence(items: Seq[YAML], comment: Option[String]) extends YAMLImplementation {
+  def setComment(comment : Option[String]) : YAMLSequence = copy(comment = comment)
+
+  def serialize: String = {
+    // create a new array of lines for this string
+    val structure = new ListBuffer[String]
+
+    // add a comment (if needed)
+    serializeComment().foreach(structure +=)
+
+    items.foreach(ai => {
+      val (i: YAML, c: Option[String]) = (ai.dropComment, ai.comment)
+      c.foreach(c => structure += YAML.serializeComment(c))
+      structure += i.serializeAs("- ")
+    })
+
+    structure.toList.mkString("\n")
+  }
+
+  /** generates a new sequence by adding values at the end of this existing list */
+  def ++(s : Seq[YAML]) : YAMLSequence = YAMLSequence(items ++ s, comment)
+  def ++(s : YAMLSequence) : YAMLSequence = s.items.toList match {
+    case Nil => this
+    case h :: tail => ++(YAML.prefixComment(h, s.comment) :: tail)
+  }
+}
+object YAMLSequence {
+  def empty : YAMLSequence = YAMLSequence(Nil, None)
+  implicit def toSequence(ys: YAMLSequence): Seq[YAML] = ys.items
+  def from(elems: YAML*) : YAMLSequence = fromSequence(elems)
+  implicit def fromSequence(s : Seq[YAML]) : YAMLSequence = YAMLSequence(s, None)
+}

--- a/src/project/src/main/scala/yaml/YAMLStructure.scala
+++ b/src/project/src/main/scala/yaml/YAMLStructure.scala
@@ -1,0 +1,61 @@
+package src.main.scala.yaml
+
+import scala.collection.mutable.ListBuffer
+
+import scala.language.implicitConversions
+import scala.language.postfixOps
+
+/** represents a key-value map of YAML Objects */
+case class YAMLStructure(map: Map[String, YAML], comment: Option[String]) extends YAMLImplementation {
+  def setComment(comment : Option[String]) : YAMLStructure = copy(comment = comment)
+
+  /** creates a new YAMLStructure by adding a set of key-value pairs to this structure */
+  def ++(m : Map[String, YAML]) : YAMLStructure = YAMLStructure(map ++ m, comment)
+
+  /** creates a new YAML Structure by adding a second set of key-value pairs to this strucutre */
+  def ++(s : YAMLStructure) : YAMLStructure = {
+    // prefix the first comment to the list that is being added
+    val newMap = s.map.toList
+    (newMap.head._1, YAML.prefixComment[YAML](newMap.head._2, s.comment)) :: newMap.tail
+    // and add that map
+    ++(newMap)
+  }
+
+  /** creates a new YAML Structure by removing a given set of key-value pairs from this structure */
+  def --(keys: String*) : YAMLStructure = YAMLStructure(map -- keys, comment)
+
+  /** serializes this structure into a string */
+  def serialize: String = {
+    // create a new array of lines for this string
+    val structure = new ListBuffer[String]
+
+    // add a comment (if needed)
+    serializeComment().foreach(structure +=)
+
+    // add key: value for each string
+    map.foreach(kv => {
+      val (key: String, comment: Option[String], value: YAML) = (kv._1, kv._2.comment, kv._2.dropComment)
+
+      // add the comment
+      comment.map(YAML.serializeComment(_)).foreach(structure +=)
+
+
+      val keySer = YAMLString.serializeString(key) + ": "
+
+      if(value.isInstanceOf[YAMLLiteral]){
+        structure += value.serializeAs(keySer)
+      } else {
+        structure += keySer
+        structure += value.serializeAs(s"  ")
+      }
+    })
+
+    // and make it a string
+    structure.toList.mkString("\n")
+  }
+}
+object YAMLStructure {
+  def empty : YAMLStructure = YAMLStructure(Map(), None)
+  implicit def toMap(ys: YAMLStructure): Map[String, YAML] = ys.map.map(kv => (YAMLString.toString(kv._1), kv._2))
+  implicit def fromMap(mp: Map[String, YAML]) : YAMLStructure = YAMLStructure(mp, None)
+}

--- a/src/travis.sbt
+++ b/src/travis.sbt
@@ -1,0 +1,65 @@
+import sbt._
+import sbt.Keys._
+
+import scala.language.implicitConversions
+import scala.language.postfixOps
+
+import src.main.scala.travis._
+
+import scala.io.Source
+
+val travisConfig = taskKey[Config]("Generate travis.yml configuration")
+travisConfig := {
+  // convenience wrapper to run an sbt task and an optional check
+  // we need to hard-code scala 2.10.7 to work on JDK 7/8/9
+  def sbt(task: String, check: Option[String] = None) = s"cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 $task)${check.map(" && cd .. && " +).getOrElse("")}"
+
+  // convenience functions for checks
+  def file(name: String) : Option[String] = Some("[[ -f \"" + name + "\" ]]")
+  def identical(name: String) : Option[String] = Some("(git diff --quiet --exit-code \"" + name + "\")")
+  def dir(name: String) : Option[String] = Some("[[ -d \"" + name + "\" ]]")
+
+  Config(
+    Scala(scalaVersion.value),
+    JDK(JDKVersion.OpenJDK7),
+    JDK(JDKVersion.OpenJDK8), JDK(JDKVersion.OracleJDK8),
+    JDK(JDKVersion.OracleJDK9)
+  )(
+    Stage("build.sbt", "check that build.sbt loads")(
+      Job("Check that build.sbt loads", sbt("exit"))()
+    ),
+
+    Stage("CodeCheck", "check that the code conforms to standards")(
+      Job("Check that the code compiles", sbt("compile"))(),
+      Job("Print scalastyle violations", sbt("scalastyle"))()
+    ),
+
+    Stage("DeployCheck", "check that the 'apidoc', 'deploy' 'genTravisYML' and 'deployFull' targets work")(
+      Job("Check mmt.jar generation using `sbt deploy`", sbt("deploy", file("deploy/mmt.jar")))(),
+      Job("Check mmt.jar generation using `sbt deployfull`", sbt("deployFull", file("deploy/mmt.jar")))(),
+      Job("Check that apidoc generation works", sbt("apidoc", dir("apidoc")))(),
+      Job("Check that `sbt genTravisYML` has been run", sbt("genTravisYML", identical(".travis.yml")))()
+    ),
+
+    Stage("test", "check that our own tests work")(
+      Job("Run MMT Tests", sbt("test"))()
+    ),
+
+    Stage("deploy", "deploy the api documentation", Some("branch = master"))(
+      Job("Auto-deploy API documentation", "bash scripts/travis/deploy_doc.sh")(JDK(JDKVersion.OpenJDK8))
+    )
+  )
+}
+
+
+val genTravisYML = taskKey[Unit]("Print out travis.yml configuration")
+genTravisYML := {
+  // read the prefix and the config
+  val prefix = Source.fromFile(Utils.src / "project" / "prefix.travis.yml").getLines.filter(!_.startsWith("##")).mkString("\n")
+  val config = travisConfig.value.serialize
+
+  // and write it into .travis.yml
+  val outFile = Utils.root / ".travis.yml"
+  IO.write(outFile, prefix + "\n" + config)
+  streams.value.log.info(s"Wrote $outFile")
+}

--- a/src/travis.sbt
+++ b/src/travis.sbt
@@ -10,6 +10,7 @@ import scala.io.Source
 
 val travisConfig = taskKey[Config]("Generate travis.yml configuration")
 travisConfig := {
+
   // convenience wrapper to run an sbt task and an optional check
   // we need to hard-code scala 2.10.7 to work on JDK 7/8/9
   def sbt(task: String, check: Option[String] = None) = s"cd src && (cat /dev/null | sbt -Dsbt.scala.version=2.10.7 $task)${check.map(" && cd .. && " +).getOrElse("")}"


### PR DESCRIPTION
Previously, mmt was only tested on Java 8 within the Travis Tests. This PR adds tests for Java 7, 8 and 9. 

In particular, it adds two new features:
1. Travis Testing for multiple versions of Java. This is achieved by introducing an sbt definition for travis tests, which automatically expands tests to be run once for each version of Java. 
2. An `sbt` mechanism to exclude specific projects from specific versions of Java, to allow for Travis Tests to pass in each of the tested java versions. 