### PR TITLE
Turn feature imports into explicit compiler flags

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -14,7 +14,7 @@ lazy val mmtMainClass = "info.kwarc.mmt.api.frontend.Run"
 // GLOBAL SETTINGS
 // =================================
 scalaVersion in Global := "2.11.12"
-scalacOptions in Global := Seq("-feature", "-deprecation", "-Xmax-classfile-name", "128")
+scalacOptions in Global := Seq("-feature", "-language:postfixOps", "-language:implicitConversions", "-deprecation", "-Xmax-classfile-name", "128")
 
 parallelExecution in ThisBuild := false
 javaOptions in ThisBuild ++= Seq("-Xmx1g")
@@ -145,6 +145,7 @@ lazy val mmt = (project in file("mmt")).
 lazy val api = (project in file("mmt-api")).
   settings(mmtProjectsSettings("mmt-api"): _*).
   settings(
+    scalacOptions in Compile ++= Seq("-language:existentials"),
     scalaSource in Compile := baseDirectory.value / "src" / "main",
     unmanagedJars in Compile += Utils.lib.toJava / "tiscaf.jar",
     unmanagedJars in Compile += Utils.lib.toJava / "scala-compiler.jar",
@@ -291,6 +292,7 @@ lazy val repl = (project in file("mmt-repl")).
 lazy val tiscaf = (project in file("tiscaf")).
   settings(commonSettings("tiscaf"): _*).
   settings(
+    scalacOptions in Compile ++= Seq("-language:reflectiveCalls"),
     scalaSource in Compile := baseDirectory.value / "src/main/scala",
     libraryDependencies ++= Seq(
       "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % "test",

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/frontend/Action.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/frontend/Action.scala
@@ -8,7 +8,6 @@ import info.kwarc.mmt.api.presentation._
 import info.kwarc.mmt.api.symbols._
 import info.kwarc.mmt.api.utils._
 
-import scala.language.postfixOps
 import scala.util.parsing.combinator._
 
 /** parser for Actions

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryExtension.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryExtension.scala
@@ -5,7 +5,6 @@ import frontend._
 import objects._
 import presentation.Presenter
 
-import scala.language.implicitConversions
 import QueryResultConversion._
 import QueryTypeConversion._
 import info.kwarc.mmt.api.libraries.LookupWithNotFoundHandler

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryResult.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryResult.scala
@@ -7,9 +7,6 @@ import info.kwarc.mmt.api.utils.xml
 import scala.collection.mutable.HashSet
 import scala.xml.Node
 
-import scala.language.implicitConversions
-
-
 /** a trait for all concrete data types that can be returned by queries; atomic types are paths and objects */
 trait BaseType
 case class XMLValue(node: scala.xml.Node) extends BaseType

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryType.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/ontology/QueryType.scala
@@ -3,8 +3,6 @@ package info.kwarc.mmt.api.ontology
 import info.kwarc.mmt.api._
 import info.kwarc.mmt.api.objects._
 
-import scala.language.implicitConversions
-
 /** QueryBaseType = Path | Obj | XML | String */
 sealed abstract class QueryBaseType(val name: String, val path: GlobalName) {
   def toTerm = OMID(path)

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/parser/Parser.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/parser/Parser.scala
@@ -9,8 +9,6 @@ import frontend._
 import objects._
 import utils._
 
-import scala.language.implicitConversions
-
 /** ParsingUnit encapsulates the input of an [[ObjectParser]]
   *
   * the top parameter can be used to parse a term that is known/required to have a certain form

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/refactoring/Translator.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/refactoring/Translator.scala
@@ -564,7 +564,6 @@ class AcrossLibraryTranslator(controller : Controller,
 
 
 
-import scala.language.implicitConversions
 import QueryResultConversion._
 import QueryTypeConversion._
 

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/utils/CompRegexParsers.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/utils/CompRegexParsers.scala
@@ -44,7 +44,6 @@ import scala.util.parsing.input._
 import scala.collection.mutable.ListBuffer
 import scala.annotation.tailrec
 import scala.collection.immutable.PagedSeq
-import scala.language.implicitConversions
 import scala.util.DynamicVariable
 import scala.util.matching.Regex
 

--- a/src/mmt-api/src/main/info/kwarc/mmt/api/utils/File.scala
+++ b/src/mmt-api/src/main/info/kwarc/mmt/api/utils/File.scala
@@ -6,7 +6,6 @@ import java.io._
 import java.util.zip._
 
 import scala.collection.mutable
-import scala.language.implicitConversions
 
 /** File wraps around java.io.File to extend it with convenience methods
   *

--- a/src/project/VersionSpecificProject.scala
+++ b/src/project/VersionSpecificProject.scala
@@ -1,4 +1,3 @@
-import scala.language.implicitConversions
 import sbt._
 
 

--- a/src/project/project.sbt
+++ b/src/project/project.sbt
@@ -1,2 +1,2 @@
 /* meta-build */
-scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
+scalacOptions in ThisBuild ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps", "-deprecation")

--- a/src/project/src/main/scala/travis/MatrixMap.scala
+++ b/src/project/src/main/scala/travis/MatrixMap.scala
@@ -2,8 +2,6 @@ package src.main.scala.travis
 
 import src.main.scala.yaml.{YAML, YAMLSequence, YAMLStructure}
 
-import scala.language.implicitConversions
-
 /** Represents an assignment of [[MatrixKey]]s to actual assignment */
 case class MatrixMap(values: List[MatrixKey[YAML]]) {
   lazy val toMap : Map[String, YAML] = values.groupBy(_.name).map(kv=>(kv._1, kv._2.head.value))

--- a/src/project/src/main/scala/yaml/YAML.scala
+++ b/src/project/src/main/scala/yaml/YAML.scala
@@ -1,7 +1,5 @@
 package src.main.scala.yaml
 
-import scala.language.postfixOps
-
 /** Implements a subset of YAML objects which can be easily serialized */
 sealed trait YAML {
   val comment: Option[String]

--- a/src/project/src/main/scala/yaml/YAMLLiteral.scala
+++ b/src/project/src/main/scala/yaml/YAMLLiteral.scala
@@ -1,7 +1,5 @@
 package src.main.scala.yaml
 
-import scala.language.implicitConversions
-
 /** represents any literal value */
 sealed abstract class YAMLLiteral(val value: String, val comment: Option[String]) extends YAMLImplementation {
   def serialize: String = if(comment.isDefined) s"$value ${YAML.serializeComment(comment.get, value + " ")}" else value

--- a/src/project/src/main/scala/yaml/YAMLSequence.scala
+++ b/src/project/src/main/scala/yaml/YAMLSequence.scala
@@ -2,9 +2,6 @@ package src.main.scala.yaml
 
 import scala.collection.mutable.ListBuffer
 
-import scala.language.implicitConversions
-import scala.language.postfixOps
-
 /** Represents a sequence of YAML objects */
 case class YAMLSequence(items: Seq[YAML], comment: Option[String]) extends YAMLImplementation {
   def setComment(comment : Option[String]) : YAMLSequence = copy(comment = comment)

--- a/src/project/src/main/scala/yaml/YAMLStructure.scala
+++ b/src/project/src/main/scala/yaml/YAMLStructure.scala
@@ -2,9 +2,6 @@ package src.main.scala.yaml
 
 import scala.collection.mutable.ListBuffer
 
-import scala.language.implicitConversions
-import scala.language.postfixOps
-
 /** represents a key-value map of YAML Objects */
 case class YAMLStructure(map: Map[String, YAML], comment: Option[String]) extends YAMLImplementation {
   def setComment(comment : Option[String]) : YAMLStructure = copy(comment = comment)

--- a/src/travis.sbt
+++ b/src/travis.sbt
@@ -1,9 +1,6 @@
 import sbt._
 import sbt.Keys._
 
-import scala.language.implicitConversions
-import scala.language.postfixOps
-
 import src.main.scala.travis._
 
 import scala.io.Source


### PR DESCRIPTION
After suggested by @florian-rabe  in #200, this commit removes all `scala.language.*` imports. Instead, we move these to `-language:*` compiler flags within our sbt configuration.