### PR TITLE
Remove shebang from building fatjar (fixes #288)

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -132,9 +132,7 @@ lazy val mmt = (project in file("mmt")).
       cp filter { j => jeditJars.contains(j.data.getName) }
     },
     mainClass in Compile := Some(mmtMainClass), 
-    mainClass in assembly := Some(mmtMainClass), 
-    assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-      prependShellScript = Some(Seq("#!/bin/bash", """exec /usr/bin/java -Xmx2048m -jar "$0" "$@"""")))
+    mainClass in assembly := Some(mmtMainClass)
   )
 
 


### PR DESCRIPTION
Previously, jars generated by `sbt deploy` contained a shebang line to be directly usable as shell scripts. This caused issues for some users (see #288) as it violates the jar standard. 

This PR removes the line from generated fatjars. Users relying on this feature should use the provided `mmt` shell script in the deploy folder instead.