### PR TITLE
Provide a Docker way to install Archives

### DIFF
--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 set -e
 
+# Ensure that the directory for content exists
 mkdir -p /content/MathHub
+
+# if the $MMT_ARCHIVES variable is set, install all the archives
+if [ ! -z "$MMT_ARCHIVES" ]; then
+    echo "Installing MMT Archives: $MMT_ARCHIVES"
+    mmt lmh install $MMT_ARCHIVES
+    echo "Done. "
+fi
+
+# And start MMT
 mmt "$@"


### PR DESCRIPTION
Previously, when MMT Arechies were needed inside an MMT Docker Container, this needed to be done manually. This was often very akward.

This commit ensures that when an MMT docker container is given the variable MMT_ARCHIVES, all archives found within in are installed.