### PR TITLE
Disable Social Buttons in TGView

### DIFF
--- a/src/mmt-api/resources/mmt-web/graphs/tgview.html
+++ b/src/mmt-api/resources/mmt-web/graphs/tgview.html
@@ -441,13 +441,15 @@
 				// Starts downloading, creating and rendering graph
 				createNewGraph(getParameterByName(graphDataURLTypeParameterNameTGView),getParameterByName(graphDataURLDataParameterNameTGView), getParameterByName(graphDataURLHighlightParameterNameTGView));
 			}
-
+			
+			/*
 			$("#shareIcons").jsSocials(
 			{
 			    showLabel: false,
 			    showCount: false,
 			    shares: ["email", "twitter", "facebook", "googleplus", "linkedin", "pinterest", "stumbleupon", "whatsapp","telegram"]
 			});
+			*/
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Because of GDPR compliance, this PR disables social buttons in tgview for now. 