### PR TITLE
Remove Oracle JDKs from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       env:
         - "INFO='Check mmt.jar generation and integration tests'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk8
+      jdk: openjdk8
       language: scala
       scala: "2.12.3"
       script:
@@ -75,7 +75,7 @@ jobs:
       env:
         - "INFO='Check mmt.jar generation and integration tests'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk11
+      jdk: openjdk11
       language: scala
       scala: "2.12.3"
       script:
@@ -89,7 +89,7 @@ jobs:
       env:
         - "INFO='Check that unit tests run'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk8
+      jdk: openjdk8
       language: scala
       scala: "2.12.3"
       script:
@@ -98,7 +98,7 @@ jobs:
       env:
         - "INFO='Check that unit tests run'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk11
+      jdk: openjdk11
       language: scala
       scala: "2.12.3"
       script:
@@ -108,7 +108,7 @@ jobs:
       env:
         - "INFO='Check lfcatalog.jar generation using `sbt deployLFCatalog`'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk8
+      jdk: openjdk8
       language: scala
       scala: "2.12.3"
       script:
@@ -119,7 +119,7 @@ jobs:
       env:
         - "INFO='Check lfcatalog.jar generation using `sbt deployLFCatalog`'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk11
+      jdk: openjdk11
       language: scala
       scala: "2.12.3"
       script:
@@ -129,7 +129,7 @@ jobs:
       env:
         - "INFO='Check that apidoc generation works'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk8
+      jdk: openjdk8
       language: scala
       scala: "2.12.3"
       script:
@@ -139,7 +139,7 @@ jobs:
       env:
         - "INFO='Check that apidoc generation works'"
         - 'SBT_VERSION_CMD="^validate"'
-      jdk: oraclejdk11
+      jdk: openjdk11
       language: scala
       scala: "2.12.3"
       script:

--- a/src/project/src/main/scala/travis/Matrix/MatrixKey.scala
+++ b/src/project/src/main/scala/travis/Matrix/MatrixKey.scala
@@ -64,9 +64,9 @@ case object IBMJava8 extends MatrixKey[YAMLString]("jdk", "ibmjava8")
 case object OpenJDK6 extends MatrixKey[YAMLString]("jdk", "openjdk6")
 case object OpenJDK7 extends MatrixKey[YAMLString]("jdk", "openjdk7")
 case object OpenJDK8 extends MatrixKey[YAMLString]("jdk", "openjdk8")
-case object OpenJDK11 extends MatrixKey[YAMLString]("jdk", "oraclejdk11")
-case object OracleJDK8 extends MatrixKey[YAMLString]("jdk", "oraclejdk8")
-case object OracleJDK9 extends MatrixKey[YAMLString]("jdk", "oraclejdk9")
+case object OpenJDK11 extends MatrixKey[YAMLString]("jdk", "openjdk11")
+// case object OracleJDK8 extends MatrixKey[YAMLString]("jdk", "oraclejdk8")
+// case object OracleJDK9 extends MatrixKey[YAMLString]("jdk", "oraclejdk9")
 
 
 /** the versions of Scala being used */

--- a/src/travis.sbt
+++ b/src/travis.sbt
@@ -27,7 +27,7 @@ travisConfig := {
 
   val LinuxTesting = MatrixSet(
     Trusty, Language("scala"), Env(Map(("SBT_VERSION_CMD", "\"^validate\""))),
-    OracleJDK8, OpenJDK11
+    OpenJDK8, OpenJDK11
   )
 
   // in principle we would test OS X as follows


### PR DESCRIPTION
After recent license changes, we have decided to remove Oracle JDK support from MMT entirely. This commit removes the last remnants of them from testing.