### PR TITLE
Fix Scala & SBT incompatbility with JDK >= 13

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -41,7 +41,7 @@ lazy val mmtMainClass = "info.kwarc.mmt.api.frontend.Run"
 // =================================
 // GLOBAL SETTINGS
 // =================================
-scalaVersion in Global := "2.12.8"
+scalaVersion in Global := "2.12.9"
 scalacOptions in Global := Seq(
   "-feature", "-language:postfixOps", "-language:implicitConversions", "-deprecation",
   "-Xmax-classfile-name", "128", // fix long classnames on weird filesystems

--- a/src/project/build.properties
+++ b/src/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3


### PR DESCRIPTION
**Not sure if that breaks anything. At least MMT compiles with it**

Also note that it doesn't work with Scala 1.13.1 due to the Scala Compiler option (apparently passed to scalac by sbt?) `-Xmax-classfile-name` is not recognized and errored with `Bad Option`.

<hr>

Previously, upon importing the SBT project in IntelliJ you would get

  java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI

with OpenJDK 13.0.1 and the Scala & SBT versions as specified in the changed files.

See scala/bug#11608 and sbt/sbt#5093.