### PR TITLE
isabelle: fix ULO namepsace

### DIFF
--- a/src/mmt-isabelle/src/info/kwarc/mmt/isabelle/Ontology.scala
+++ b/src/mmt-isabelle/src/info/kwarc/mmt/isabelle/Ontology.scala
@@ -26,7 +26,7 @@ object Ontology
 
   /* namespace */
 
-  val ulo: isabelle.XML.Namespace = isabelle.XML.Namespace("ulo", "https://mathhub.info/ulo")
+  val ulo: isabelle.XML.Namespace = isabelle.XML.Namespace("ulo", "https://mathhub.info/ulo#")
 
   def rdf_document(triples: List[isabelle.RDF.Triple]): isabelle.XML.Elem =
     isabelle.RDF.document(isabelle.RDF.triples(triples),


### PR DESCRIPTION
This patch fixes a typo in the XML namespace. If you look at the [ontology file](https://gl.mathhub.info/ulo/ulo/-/blob/master/ulo.owl) you see that the XML namespace ends with a hash.