### PR TITLE
fix deploy/run-file

### DIFF
--- a/deploy/run-file
+++ b/deploy/run-file
@@ -3,4 +3,4 @@
 # This is like run except that it automatically loads an msl file passed as an argument.
 # You may want to associate the msl file ending with this script.
 dir="$(dirname $0)"
-java -Xmx8192m -cp "$dir/lib/*:$dir/mmt.jar" info.kwarc.mmt.api.frontend.Run :file $1
+java -Xmx8192m -cp "$dir/mmt.jar" info.kwarc.mmt.api.frontend.Run :file $1


### PR DESCRIPTION
removed conflicting lib folder from class path as it is not used anymore.

See this [matrix message and the following conversation](https://matrix.to/#/!qDmMOKIjDlILnlfqAj:fau.de/$_UEPsnc6VTblEasXZ-_DBL7k6jKJYpmVeXT48bJfFZY?via=fau.de&via=matrix.org) @florian-rabe 

---
`MMT/deploy/run-file` chrashes with the following error when running it on the git-bash for windows (couldn't test unix bash):

```
$ ../MMT/deploy/run-file build.msl
Fehler: Hauptklasse info.kwarc.mmt.api.frontend.Run konnte nicht gefunden oder geladen werden
Ursache: java.lang.ClassNotFoundException: info.kwarc.mmt.api.frontend.Run
```

When comparing it with the cmd version the class path differs:

cmd:

```cmd
call java -Xmx1024m -cp %~dp0/mmt.jar info.kwarc.mmt.api.frontend.Run :file %1
```

bash:

```bash
dir="$(dirname $0)"
java -Xmx8192m -cp "$dir/lib/*:$dir/mmt.jar" info.kwarc.mmt.api.frontend.Run :file $1
```

The bash version works when I remove `$dir/lib/*:` from the class path.